### PR TITLE
Feat/board search

### DIFF
--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -3,6 +3,7 @@ package nemeton
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"okp4/nemeton-leaderboard/app/util"
 
@@ -84,7 +85,7 @@ func (s *Store) ensureIndexes(ctx context.Context) error {
 				{Keys: bson.M{"moniker": 1}},
 				{Keys: bson.M{"valoper": 1}, Options: options.Index().SetUnique(true)},
 				{Keys: bson.M{"delegator": 1}, Options: options.Index().SetUnique(true)},
-				{Keys: bson.M{"twitter": 1}, Options: options.Index().SetUnique(true)},
+				{Keys: bson.M{"twitter": 1}, Options: options.Index().SetSparse(true).SetUnique(true)},
 				{Keys: bson.M{"discord": 1}, Options: options.Index().SetUnique(true)},
 			},
 		)
@@ -192,24 +193,10 @@ func (s *Store) CountValidators(ctx context.Context) (int64, error) {
 	return s.db.Collection(validatorsCollectionName).CountDocuments(ctx, bson.M{})
 }
 
-func (s *Store) GetBoard(ctx context.Context, limit int, after *Cursor) ([]*Validator, bool, error) {
-	var filter bson.M
-	if after != nil {
-		filter = bson.M{
-			"$or": bson.A{
-				bson.M{
-					"points": bson.M{"$lt": after.points},
-				},
-				bson.M{
-					"points": after.points,
-					"_id":    bson.M{"$gt": after.objectID},
-				},
-			},
-		}
-	}
+func (s *Store) GetBoard(ctx context.Context, search *string, limit int, after *Cursor) ([]*Validator, bool, error) {
 	c, err := s.db.Collection(validatorsCollectionName).Find(
 		ctx,
-		filter,
+		makeBoardFilter(search, after),
 		options.Find().
 			SetSort(
 				bson.D{
@@ -238,4 +225,38 @@ func (s *Store) GetBoard(ctx context.Context, limit int, after *Cursor) ([]*Vali
 	}
 
 	return validators, c.Next(ctx), nil
+}
+
+func makeBoardFilter(search *string, after *Cursor) bson.M {
+	filters := bson.A{}
+	if after != nil {
+		filters = append(filters, bson.M{
+			"$or": bson.A{
+				bson.M{
+					"points": bson.M{"$lt": after.points},
+				},
+				bson.M{
+					"points": after.points,
+					"_id":    bson.M{"$gt": after.objectID},
+				},
+			},
+		})
+	}
+	if search != nil {
+		filters = append(filters, bson.M{
+			"$or": bson.A{
+				bson.M{"moniker": bson.M{"$regex": fmt.Sprintf(".*%s.*", *search), "$options": "i"}},
+				bson.M{"valoper": bson.M{"$regex": fmt.Sprintf(".*%s.*", *search), "$options": "i"}},
+				bson.M{"delegator": bson.M{"$regex": fmt.Sprintf(".*%s.*", *search), "$options": "i"}},
+			},
+		})
+	}
+
+	var filter bson.M
+	if len(filters) > 0 {
+		filter = bson.M{
+			"$and": filters,
+		}
+	}
+	return filter
 }

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -65,7 +65,7 @@ func (r *queryResolver) Phases(ctx context.Context) (*model.Phases, error) {
 
 // Board is the resolver for the board field.
 func (r *queryResolver) Board(ctx context.Context, search *string, first *int, after *nemeton.Cursor) (*model.BoardConnection, error) {
-	validators, hasNext, err := r.store.GetBoard(ctx, *first, after)
+	validators, hasNext, err := r.store.GetBoard(ctx, search, *first, after)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
🔍  Implement search feature when requesting the board.

## Details

The research is achieved by filtering the results, not actively searching for them. This means the sorting result stays ordered by rank ascending, and the pagination through cursor still works.

The search is done by filtering through a case insensitive regex expressing a contains condition applied on the following fields:
- `moniker`
- `valoper`
- `delegator`