### PR TITLE
Feat/validator details

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -97,6 +97,7 @@ type ComplexityRoot struct {
 		CompletedCount func(childComplexity int) int
 		FinishedCount  func(childComplexity int) int
 		Phase          func(childComplexity int) int
+		Points         func(childComplexity int) int
 		StartedCount   func(childComplexity int) int
 		Tasks          func(childComplexity int) int
 	}
@@ -376,6 +377,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PerPhaseTasks.Phase(childComplexity), true
+
+	case "PerPhaseTasks.points":
+		if e.complexity.PerPhaseTasks.Points == nil {
+			break
+		}
+
+		return e.complexity.PerPhaseTasks.Points(childComplexity), true
 
 	case "PerPhaseTasks.startedCount":
 		if e.complexity.PerPhaseTasks.StartedCount == nil {
@@ -1397,6 +1405,11 @@ type PerPhaseTasks {
     The total number of finished tasks in this phase.
     """
     finishedCount: Int!
+
+    """
+    The current points earned by the validator in this phase.
+    """
+    points: UInt64!
 
     """
     The phase we're talking about.
@@ -2629,6 +2642,50 @@ func (ec *executionContext) fieldContext_PerPhaseTasks_finishedCount(ctx context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PerPhaseTasks_points(ctx context.Context, field graphql.CollectedField, obj *model.PerPhaseTasks) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PerPhaseTasks_points(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Points, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PerPhaseTasks_points(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PerPhaseTasks",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4624,6 +4681,8 @@ func (ec *executionContext) fieldContext_Tasks_perPhase(ctx context.Context, fie
 				return ec.fieldContext_PerPhaseTasks_startedCount(ctx, field)
 			case "finishedCount":
 				return ec.fieldContext_PerPhaseTasks_finishedCount(ctx, field)
+			case "points":
+				return ec.fieldContext_PerPhaseTasks_points(ctx, field)
 			case "phase":
 				return ec.fieldContext_PerPhaseTasks_phase(ctx, field)
 			case "tasks":
@@ -4677,6 +4736,8 @@ func (ec *executionContext) fieldContext_Tasks_forPhase(ctx context.Context, fie
 				return ec.fieldContext_PerPhaseTasks_startedCount(ctx, field)
 			case "finishedCount":
 				return ec.fieldContext_PerPhaseTasks_finishedCount(ctx, field)
+			case "points":
+				return ec.fieldContext_PerPhaseTasks_points(ctx, field)
 			case "phase":
 				return ec.fieldContext_PerPhaseTasks_phase(ctx, field)
 			case "tasks":
@@ -7891,6 +7952,13 @@ func (ec *executionContext) _PerPhaseTasks(ctx context.Context, sel ast.Selectio
 		case "finishedCount":
 
 			out.Values[i] = ec._PerPhaseTasks_finishedCount(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "points":
+
+			out.Values[i] = ec._PerPhaseTasks_points(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -100,6 +100,8 @@ type PerPhaseTasks struct {
 	StartedCount int `json:"startedCount"`
 	// The total number of finished tasks in this phase.
 	FinishedCount int `json:"finishedCount"`
+	// The current points earned by the validator in this phase.
+	Points uint64 `json:"points"`
 	// The phase we're talking about.
 	Phase *nemeton.Phase `json:"phase"`
 	// The current status of the phase's tasks for a validator.

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -506,6 +506,11 @@ type PerPhaseTasks {
     finishedCount: Int!
 
     """
+    The current points earned by the validator in this phase.
+    """
+    points: UInt64!
+
+    """
     The phase we're talking about.
     """
     phase: Phase!

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -208,6 +208,7 @@ func (r *validatorResolver) Tasks(ctx context.Context, obj *nemeton.Validator) (
 			CompletedCount: 0,
 			StartedCount:   0,
 			FinishedCount:  0,
+			Points:         0,
 			Phase:          phase,
 		}
 		for i, task := range phase.Tasks {
@@ -229,6 +230,7 @@ func (r *validatorResolver) Tasks(ctx context.Context, obj *nemeton.Validator) (
 				perPhase.FinishedCount++
 			}
 			perPhase.Tasks = append(perPhase.Tasks, mappedState)
+			perPhase.Points += mappedState.EarnedPoints
 		}
 
 		result.CompletedCount += perPhase.CompletedCount

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -203,7 +203,7 @@ func (r *validatorResolver) Tasks(ctx context.Context, obj *nemeton.Validator) (
 		StartedCount:   0,
 		FinishedCount:  0,
 	}
-	for _, phase := range append(r.store.GetFinishedPhases(), r.store.GetCurrentPhase()) {
+	for _, phase := range r.store.GetAllPhases() {
 		perPhase := &model.PerPhaseTasks{
 			CompletedCount: 0,
 			StartedCount:   0,


### PR DESCRIPTION
Some API improvements regarding the validator details page needs:

Provide the points earned per phase by adding the `points` field in the `PerPhaseTasks` type, for example:
```graphql
query {
  validator(cursor: "mycursor") {
    tasks {
      perPhase {
        points
      }
    }
  }
}
```

In the `perPhase` field of the `Tasks` type, return all the phases.