### PR TITLE
🔗 Register RPC endpoint

### DIFF
--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -209,7 +209,7 @@ func (a *Actor) handleRegisterRPCEndpointEvent(data map[string]interface{}) {
 		return
 	}
 
-	if err := a.store.RegisterValidatorRPC(a.ctx, e.Moniker, e.Url); err != nil {
+	if err := a.store.RegisterValidatorRPC(a.ctx, e.Moniker, e.URL); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register/update validator rpc endpoint")
 	}
 }

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -87,6 +87,8 @@ func (a *Actor) receiveNewEvent(e event.Event) {
 		a.handleGenTXSubmittedEvent(e.Date, e.Data)
 	case tweet.NewTweetEventType:
 		a.handleNewTweetEvent(e.Date, e.Data)
+	case graphql.RegisterRPCEndpointEventType:
+		a.handleRegisterRPCEndpointEvent(e.Data)
 	default:
 		log.Warn().Msg("⚠️ No event handler for this event.")
 	}
@@ -196,4 +198,18 @@ func (a *Actor) handlePhaseEnded(phase *nemeton.Phase) {
 
 func (a *Actor) handlePhaseStarted(phase *nemeton.Phase) {
 	// TODO: handle phase started
+}
+
+func (a *Actor) handleRegisterRPCEndpointEvent(data map[string]interface{}) {
+	log.Info().Interface("event", data).Msg("Handle RegisterRPC event")
+
+	e, err := graphql.UnmarshallRegisterRPCEndpointEvent(data)
+	if err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshall event to RegisterRPCEndpointEvent")
+		return
+	}
+
+	if err := a.store.RegisterValidatorRPC(a.ctx, e.Moniker, e.Url); err != nil {
+		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register/update validator rpc endpoint")
+	}
 }

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -209,7 +209,7 @@ func (a *Actor) handleRegisterRPCEndpointEvent(when time.Time, data map[string]i
 		return
 	}
 
-	if err := a.store.RegisterValidatorRPC(a.ctx, when, e.Moniker, e.URL); err != nil {
+	if err := a.store.RegisterValidatorRPC(a.ctx, when, e.Validator, e.URL); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register/update validator rpc endpoint")
 	}
 }

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -88,7 +88,7 @@ func (a *Actor) receiveNewEvent(e event.Event) {
 	case tweet.NewTweetEventType:
 		a.handleNewTweetEvent(e.Date, e.Data)
 	case graphql.RegisterRPCEndpointEventType:
-		a.handleRegisterRPCEndpointEvent(e.Data)
+		a.handleRegisterRPCEndpointEvent(e.Date, e.Data)
 	default:
 		log.Warn().Msg("⚠️ No event handler for this event.")
 	}
@@ -200,7 +200,7 @@ func (a *Actor) handlePhaseStarted(phase *nemeton.Phase) {
 	// TODO: handle phase started
 }
 
-func (a *Actor) handleRegisterRPCEndpointEvent(data map[string]interface{}) {
+func (a *Actor) handleRegisterRPCEndpointEvent(when time.Time, data map[string]interface{}) {
 	log.Info().Interface("event", data).Msg("Handle RegisterRPC event")
 
 	e, err := graphql.UnmarshallRegisterRPCEndpointEvent(data)
@@ -209,7 +209,7 @@ func (a *Actor) handleRegisterRPCEndpointEvent(data map[string]interface{}) {
 		return
 	}
 
-	if err := a.store.RegisterValidatorRPC(a.ctx, e.Moniker, e.URL); err != nil {
+	if err := a.store.RegisterValidatorRPC(a.ctx, when, e.Moniker, e.URL); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register/update validator rpc endpoint")
 	}
 }

--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"okp4/nemeton-leaderboard/app/util"
@@ -317,6 +318,18 @@ func (s *Store) CreateValidator(
 	validator.Tasks = tasks
 
 	_, err = s.db.Collection(validatorsCollectionName).InsertOne(ctx, validator)
+	return err
+}
+
+func (s *Store) RegisterValidatorRPC(ctx context.Context, moniker string, rpc *url.URL) error {
+	filter := bson.M{"moniker": moniker}
+	_, err := s.db.Collection(validatorsCollectionName).UpdateOne(ctx,
+		filter,
+		bson.M{"$set": bson.M{"rpcEndpoint": rpc}},
+	)
+
+	// TODO: get phase and task to add rewards.
+	// s.ensureTaskCompleted(ctx, filter)
 	return err
 }
 

--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -317,8 +317,8 @@ func (s *Store) CreateValidator(
 	return err
 }
 
-func (s *Store) RegisterValidatorRPC(ctx context.Context, when time.Time, moniker string, rpc *url.URL) error {
-	filter := bson.M{"moniker": moniker}
+func (s *Store) RegisterValidatorRPC(ctx context.Context, when time.Time, validator types.ValAddress, rpc *url.URL) error {
+	filter := bson.M{"valoper": validator}
 	_, err := s.db.Collection(validatorsCollectionName).UpdateOne(ctx,
 		filter,
 		bson.M{"$set": bson.M{"rpcEndpoint": rpc}},

--- a/app/nemeton/validator.go
+++ b/app/nemeton/validator.go
@@ -11,20 +11,21 @@ import (
 )
 
 type Validator struct {
-	ID        primitive.ObjectID           `bson:"_id,omitempty"`
-	Moniker   string                       `bson:"moniker"`
-	Identity  *string                      `bson:"identity,omitempty"`
-	Details   *string                      `bson:"details,omitempty"`
-	Valoper   types.ValAddress             `bson:"valoper"`
-	Delegator types.AccAddress             `bson:"delegator"`
-	Valcons   types.ConsAddress            `bson:"valcons"`
-	Twitter   *string                      `bson:"twitter,omitempty"`
-	Website   *url.URL                     `bson:"website,omitempty"`
-	Discord   string                       `bson:"discord"`
-	Country   string                       `bson:"country"`
-	Status    string                       `bson:"status"`
-	Points    uint64                       `bson:"points"`
-	Tasks     map[int]map[string]TaskState `bson:"tasks"`
+	ID          primitive.ObjectID           `bson:"_id,omitempty"`
+	Moniker     string                       `bson:"moniker"`
+	Identity    *string                      `bson:"identity,omitempty"`
+	Details     *string                      `bson:"details,omitempty"`
+	Valoper     types.ValAddress             `bson:"valoper"`
+	Delegator   types.AccAddress             `bson:"delegator"`
+	Valcons     types.ConsAddress            `bson:"valcons"`
+	Twitter     *string                      `bson:"twitter,omitempty"`
+	Website     *url.URL                     `bson:"website,omitempty"`
+	Discord     string                       `bson:"discord"`
+	Country     string                       `bson:"country"`
+	RPCEndpoint *url.URL                     `bson:"rpcEndpoint"`
+	Status      string                       `bson:"status"`
+	Points      uint64                       `bson:"points"`
+	Tasks       map[int]map[string]TaskState `bson:"tasks"`
 }
 
 func MakeValidator(createMsg *stakingtypes.MsgCreateValidator, discord, country string, twitter *string) (*Validator, error) {

--- a/app/nemeton/validator.go
+++ b/app/nemeton/validator.go
@@ -22,7 +22,7 @@ type Validator struct {
 	Website     *url.URL                     `bson:"website,omitempty"`
 	Discord     string                       `bson:"discord"`
 	Country     string                       `bson:"country"`
-	RPCEndpoint *url.URL                     `bson:"rpcEndpoint"`
+	RPCEndpoint *url.URL                     `bson:"rpcEndpoint,omitempty"`
 	Status      string                       `bson:"status"`
 	Points      uint64                       `bson:"points"`
 	Tasks       map[int]map[string]TaskState `bson:"tasks"`

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
-	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -844,8 +844,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 h1:cu5kTvlzcw1Q5S9f5ip1/cpiB4nXvw1XYzFPGgzLUOY=
-golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -39,7 +39,7 @@ func Unmarshall(data map[string]interface{}) (*GenTXSubmittedEvent, error) {
 
 type RegisterRPCEndpointEvent struct {
 	Moniker string   `json:"moniker"`
-	Url     *url.URL `json:"url"`
+	URL     *url.URL `json:"url"`
 }
 
 func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -38,8 +38,8 @@ func Unmarshall(data map[string]interface{}) (*GenTXSubmittedEvent, error) {
 }
 
 type RegisterRPCEndpointEvent struct {
-	Validator string   `json:"validator"`
-	url       *url.URL `json:"url"`
+	Moniker string   `json:"moniker"`
+	Url     *url.URL `json:"url"`
 }
 
 func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -1,8 +1,14 @@
 package graphql
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net/url"
+)
 
-const GenTXSubmittedEventType = "gentx-submitted"
+const (
+	GenTXSubmittedEventType      = "gentx-submitted"
+	RegisterRPCEndpointEventType = "register-rpc-endpoint"
+)
 
 type GenTXSubmittedEvent struct {
 	Twitter *string                `json:"twitter,omitempty"`
@@ -23,6 +29,31 @@ func (e *GenTXSubmittedEvent) Marshall() (map[string]interface{}, error) {
 
 func Unmarshall(data map[string]interface{}) (*GenTXSubmittedEvent, error) {
 	var event *GenTXSubmittedEvent
+	d, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(d, &event)
+	return event, err
+}
+
+type RegisterRPCEndpointEvent struct {
+	Validator string   `json:"validator"`
+	url       *url.URL `json:"url"`
+}
+
+func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {
+	var event map[string]interface{}
+	data, err := json.Marshal(&e)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &event)
+	return event, err
+}
+
+func UnmarshallRegisterRPCEndpointEvent(data map[string]interface{}) (*RegisterRPCEndpointEvent, error) {
+	var event *RegisterRPCEndpointEvent
 	d, err := json.Marshal(data)
 	if err != nil {
 		return nil, err

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -3,6 +3,8 @@ package graphql
 import (
 	"encoding/json"
 	"net/url"
+
+	"github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -38,8 +40,8 @@ func Unmarshall(data map[string]interface{}) (*GenTXSubmittedEvent, error) {
 }
 
 type RegisterRPCEndpointEvent struct {
-	Moniker string   `json:"moniker"`
-	URL     *url.URL `json:"url"`
+	Validator types.ValAddress `json:"validator"`
+	URL       *url.URL         `json:"url"`
 }
 
 func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -8,14 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"okp4/nemeton-leaderboard/app/nemeton"
+	"okp4/nemeton-leaderboard/graphql/model"
+	"okp4/nemeton-leaderboard/graphql/scalar"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"okp4/nemeton-leaderboard/app/nemeton"
-	"okp4/nemeton-leaderboard/graphql/model"
-	"okp4/nemeton-leaderboard/graphql/scalar"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
@@ -77,6 +76,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		RegisterRPCEndpoint  func(childComplexity int, validator string, url *url.URL) int
 		SubmitValidatorGenTx func(childComplexity int, twitter *string, discord string, country string, gentx map[string]interface{}) int
 	}
 
@@ -176,6 +176,7 @@ type IdentityResolver interface {
 }
 type MutationResolver interface {
 	SubmitValidatorGenTx(ctx context.Context, twitter *string, discord string, country string, gentx map[string]interface{}) (*string, error)
+	RegisterRPCEndpoint(ctx context.Context, validator string, url *url.URL) (*string, error)
 }
 type PhaseResolver interface {
 	Blocks(ctx context.Context, obj *nemeton.Phase) (*model.BlockRange, error)
@@ -277,6 +278,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Link.Href(childComplexity), true
+
+	case "Mutation.registerRPCEndpoint":
+		if e.complexity.Mutation.RegisterRPCEndpoint == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_registerRPCEndpoint_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RegisterRPCEndpoint(childComplexity, args["validator"].(string), args["url"].(*url.URL)), true
 
 	case "Mutation.submitValidatorGenTX":
 		if e.complexity.Mutation.SubmitValidatorGenTx == nil {
@@ -939,6 +952,24 @@ type Mutation {
         """
         gentx: JSON!
     ): Void @auth
+
+    """
+    Emit a ` + "`" + `RegisterRPCEndpointEvent` + "`" + ` in the system to register RPC node url for the given druid validator.
+
+    Through the event handling logic, the validator will be fulfilled with his RPC endpoint url and task completed with points
+    attribution if still in progress. If event is submitted multiple time, RPC endpoint is updated.
+    """
+    registerRPCEndpoint(
+        """
+        The validator ID that will register the RPC endpoint.
+        """
+        validator: ID!
+
+        """
+        The RPC endpoint url of validator.
+        """
+        url: URI!
+    ): Void @auth
 }
 
 """
@@ -1341,6 +1372,30 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_registerRPCEndpoint_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["validator"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validator"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["validator"] = arg0
+	var arg1 *url.URL
+	if tmp, ok := rawArgs["url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
+		arg1, err = ec.unmarshalNURI2ᚖnetᚋurlᚐURL(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["url"] = arg1
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_submitValidatorGenTX_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -1995,6 +2050,78 @@ func (ec *executionContext) fieldContext_Mutation_submitValidatorGenTX(ctx conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_submitValidatorGenTX_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_registerRPCEndpoint(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_registerRPCEndpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().RegisterRPCEndpoint(rctx, fc.Args["validator"].(string), fc.Args["url"].(*url.URL))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Auth == nil {
+				return nil, errors.New("directive auth is not implemented")
+			}
+			return ec.directives.Auth(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*string); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOVoid2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_registerRPCEndpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Void does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_registerRPCEndpoint_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -6970,6 +7097,7 @@ func (ec *executionContext) _Identity(ctx context.Context, sel ast.SelectionSet,
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7033,6 +7161,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_submitValidatorGenTX(ctx, field)
+			})
+
+		case "registerRPCEndpoint":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_registerRPCEndpoint(ctx, field)
 			})
 
 		default:
@@ -7233,6 +7367,7 @@ func (ec *executionContext) _Phase(ctx context.Context, sel ast.SelectionSet, ob
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7273,6 +7408,7 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "ongoing":
 			field := field
@@ -7292,6 +7428,7 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "finished":
 			field := field
@@ -7311,6 +7448,7 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "current":
 			field := field
@@ -7327,6 +7465,7 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7659,6 +7798,7 @@ func (ec *executionContext) _Tasks(ctx context.Context, sel ast.SelectionSet, ob
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7699,6 +7839,7 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "moniker":
 
@@ -7722,6 +7863,7 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "details":
 
@@ -7781,6 +7923,7 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "points":
 
@@ -7807,6 +7950,7 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		case "missedBlocks":
 			field := field
@@ -7826,6 +7970,7 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
+
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -157,6 +157,7 @@ type ComplexityRoot struct {
 		MissedBlocks func(childComplexity int) int
 		Moniker      func(childComplexity int) int
 		Points       func(childComplexity int) int
+		RPCEndpoint  func(childComplexity int) int
 		Rank         func(childComplexity int) int
 		Status       func(childComplexity int) int
 		Tasks        func(childComplexity int) int
@@ -202,6 +203,7 @@ type ValidatorResolver interface {
 
 	Identity(ctx context.Context, obj *nemeton.Validator) (*model.Identity, error)
 
+	RPCEndpoint(ctx context.Context, obj *nemeton.Validator) (*url.URL, error)
 	Status(ctx context.Context, obj *nemeton.Validator) (model.ValidatorStatus, error)
 
 	Tasks(ctx context.Context, obj *nemeton.Validator) (*model.Tasks, error)
@@ -686,6 +688,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Validator.Points(childComplexity), true
+
+	case "Validator.rpcEndpoint":
+		if e.complexity.Validator.RPCEndpoint == nil {
+			break
+		}
+
+		return e.complexity.Validator.RPCEndpoint(childComplexity), true
 
 	case "Validator.rank":
 		if e.complexity.Validator.Rank == nil {
@@ -1220,6 +1229,11 @@ type Validator {
     The validator country.
     """
     country: String!
+
+    """
+    The validator rpc node endpoint.
+    """
+    rpcEndpoint: URI
 
     """
     The validator current status.
@@ -3549,6 +3563,8 @@ func (ec *executionContext) fieldContext_Query_validator(ctx context.Context, fi
 				return ec.fieldContext_Validator_discord(ctx, field)
 			case "country":
 				return ec.fieldContext_Validator_country(ctx, field)
+			case "rpcEndpoint":
+				return ec.fieldContext_Validator_rpcEndpoint(ctx, field)
 			case "status":
 				return ec.fieldContext_Validator_status(ctx, field)
 			case "points":
@@ -4893,6 +4909,47 @@ func (ec *executionContext) fieldContext_Validator_country(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Validator_rpcEndpoint(ctx context.Context, field graphql.CollectedField, obj *nemeton.Validator) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Validator_rpcEndpoint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Validator().RPCEndpoint(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*url.URL)
+	fc.Result = res
+	return ec.marshalOURI2ᚖnetᚋurlᚐURL(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Validator_rpcEndpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Validator",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type URI does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Validator_status(ctx context.Context, field graphql.CollectedField, obj *nemeton.Validator) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Validator_status(ctx, field)
 	if err != nil {
@@ -5192,6 +5249,8 @@ func (ec *executionContext) fieldContext_ValidatorEdge_node(ctx context.Context,
 				return ec.fieldContext_Validator_discord(ctx, field)
 			case "country":
 				return ec.fieldContext_Validator_country(ctx, field)
+			case "rpcEndpoint":
+				return ec.fieldContext_Validator_rpcEndpoint(ctx, field)
 			case "status":
 				return ec.fieldContext_Validator_status(ctx, field)
 			case "points":
@@ -7905,6 +7964,23 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "rpcEndpoint":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Validator_rpcEndpoint(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "status":
 			field := field
 

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -76,7 +76,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		RegisterRPCEndpoint  func(childComplexity int, moniker string, url *url.URL) int
+		RegisterRPCEndpoint  func(childComplexity int, validator types.ValAddress, url *url.URL) int
 		SubmitValidatorGenTx func(childComplexity int, twitter *string, discord string, country string, gentx map[string]interface{}) int
 	}
 
@@ -177,7 +177,7 @@ type IdentityResolver interface {
 }
 type MutationResolver interface {
 	SubmitValidatorGenTx(ctx context.Context, twitter *string, discord string, country string, gentx map[string]interface{}) (*string, error)
-	RegisterRPCEndpoint(ctx context.Context, moniker string, url *url.URL) (*string, error)
+	RegisterRPCEndpoint(ctx context.Context, validator types.ValAddress, url *url.URL) (*string, error)
 }
 type PhaseResolver interface {
 	Blocks(ctx context.Context, obj *nemeton.Phase) (*model.BlockRange, error)
@@ -290,7 +290,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.RegisterRPCEndpoint(childComplexity, args["moniker"].(string), args["url"].(*url.URL)), true
+		return e.complexity.Mutation.RegisterRPCEndpoint(childComplexity, args["validator"].(types.ValAddress), args["url"].(*url.URL)), true
 
 	case "Mutation.submitValidatorGenTX":
 		if e.complexity.Mutation.SubmitValidatorGenTx == nil {
@@ -969,9 +969,9 @@ type Mutation {
     """
     registerRPCEndpoint(
         """
-        The validator moniker that will register the RPC endpoint.
+        The valoper address of the validator that will register the RPC endpoint.
         """
-        moniker: String!
+        validator: ValoperAddress!
 
         """
         The RPC endpoint url of validator.
@@ -1389,15 +1389,15 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 func (ec *executionContext) field_Mutation_registerRPCEndpoint_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 string
-	if tmp, ok := rawArgs["moniker"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("moniker"))
-		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+	var arg0 types.ValAddress
+	if tmp, ok := rawArgs["validator"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validator"))
+		arg0, err = ec.unmarshalNValoperAddress2githubᚗcomᚋcosmosᚋcosmosᚑsdkᚋtypesᚐValAddress(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["moniker"] = arg0
+	args["validator"] = arg0
 	var arg1 *url.URL
 	if tmp, ok := rawArgs["url"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
@@ -2084,7 +2084,7 @@ func (ec *executionContext) _Mutation_registerRPCEndpoint(ctx context.Context, f
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().RegisterRPCEndpoint(rctx, fc.Args["moniker"].(string), fc.Args["url"].(*url.URL))
+			return ec.resolvers.Mutation().RegisterRPCEndpoint(rctx, fc.Args["validator"].(types.ValAddress), fc.Args["url"].(*url.URL))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.Auth == nil {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strconv"
-
 	"okp4/nemeton-leaderboard/app/nemeton"
+	"strconv"
 )
 
 // Represents a blockchain block range.

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -410,6 +410,11 @@ type Validator {
     country: String!
 
     """
+    The validator rpc node endpoint.
+    """
+    rpcEndpoint: URI
+
+    """
     The validator current status.
     """
     status: ValidatorStatus!

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -140,6 +140,24 @@ type Mutation {
         """
         gentx: JSON!
     ): Void @auth
+
+    """
+    Emit a `RegisterRPCEndpointEvent` in the system to register RPC node url for the given druid validator.
+
+    Through the event handling logic, the validator will be fulfilled with his RPC endpoint url and task completed with points
+    attribution if still in progress. If event is submitted multiple time, RPC endpoint is updated.
+    """
+    registerRPCEndpoint(
+        """
+        The validator ID that will register the RPC endpoint.
+        """
+        validator: ID!
+
+        """
+        The RPC endpoint url of validator.
+        """
+        url: URI!
+    ): Void @auth
 }
 
 """

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -149,9 +149,9 @@ type Mutation {
     """
     registerRPCEndpoint(
         """
-        The validator ID that will register the RPC endpoint.
+        The validator moniker that will register the RPC endpoint.
         """
-        validator: ID!
+        moniker: String!
 
         """
         The RPC endpoint url of validator.

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -149,9 +149,9 @@ type Mutation {
     """
     registerRPCEndpoint(
         """
-        The validator moniker that will register the RPC endpoint.
+        The valoper address of the validator that will register the RPC endpoint.
         """
-        moniker: String!
+        validator: ValoperAddress!
 
         """
         The RPC endpoint url of validator.

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -215,6 +215,11 @@ func (r *validatorResolver) Identity(ctx context.Context, obj *nemeton.Validator
 	}, nil
 }
 
+// RPCEndpoint is the resolver for the rpcEndpoint field.
+func (r *validatorResolver) RPCEndpoint(ctx context.Context, obj *nemeton.Validator) (*url.URL, error) {
+	return obj.RPCEndpoint, nil
+}
+
 // Status is the resolver for the status field.
 func (r *validatorResolver) Status(ctx context.Context, obj *nemeton.Validator) (model.ValidatorStatus, error) {
 	panic(fmt.Errorf("not implemented: Status - status"))

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -61,7 +61,7 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, moniker string, url *url.URL) (*string, error) {
 	evt := RegisterRPCEndpointEvent{
 		Moniker: moniker,
-		Url:     url,
+		URL:     url,
 	}
 	rawEvt, err := evt.Marshall()
 	if err != nil {
@@ -301,13 +301,3 @@ type (
 	tasksResolver     struct{ *Resolver }
 	validatorResolver struct{ *Resolver }
 )
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *validatorResolver) RPCEndpoint(ctx context.Context, obj *nemeton.Validator) (*url.URL, error) {
-	return obj.RPCEndpoint, nil
-}

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -7,6 +7,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"okp4/nemeton-leaderboard/app/event"
 	"okp4/nemeton-leaderboard/app/message"
@@ -54,6 +55,11 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 		},
 	)
 	return nil, nil
+}
+
+// RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.
+func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator string, url *url.URL) (*string, error) {
+	panic(fmt.Errorf("not implemented: RegisterRPCEndpoint - registerRPCEndpoint"))
 }
 
 // Blocks is the resolver for the blocks field.

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -59,7 +59,25 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 
 // RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.
 func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator string, url *url.URL) (*string, error) {
-	panic(fmt.Errorf("not implemented: RegisterRPCEndpoint - registerRPCEndpoint"))
+	evt := RegisterRPCEndpointEvent{
+		Validator: validator,
+		url:       url,
+	}
+	rawEvt, err := evt.Marshall()
+	if err != nil {
+		return nil, err
+	}
+
+	r.actorCTX.Send(
+		r.eventStore,
+		&message.PublishEventMessage{
+			Event: event.NewEvent(
+				RegisterRPCEndpointEventType,
+				rawEvt,
+			),
+		},
+	)
+	return nil, nil
 }
 
 // Blocks is the resolver for the blocks field.

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -58,10 +58,10 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 }
 
 // RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.
-func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, moniker string, url *url.URL) (*string, error) {
+func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator types.ValAddress, url *url.URL) (*string, error) {
 	evt := RegisterRPCEndpointEvent{
-		Moniker: moniker,
-		URL:     url,
+		Validator: validator,
+		URL:       url,
 	}
 	rawEvt, err := evt.Marshall()
 	if err != nil {

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -58,10 +58,10 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 }
 
 // RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.
-func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator string, url *url.URL) (*string, error) {
+func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, moniker string, url *url.URL) (*string, error) {
 	evt := RegisterRPCEndpointEvent{
-		Validator: validator,
-		url:       url,
+		Moniker: moniker,
+		Url:     url,
 	}
 	rawEvt, err := evt.Marshall()
 	if err != nil {
@@ -215,11 +215,6 @@ func (r *validatorResolver) Identity(ctx context.Context, obj *nemeton.Validator
 	}, nil
 }
 
-// RPCEndpoint is the resolver for the rpcEndpoint field.
-func (r *validatorResolver) RPCEndpoint(ctx context.Context, obj *nemeton.Validator) (*url.URL, error) {
-	return obj.RPCEndpoint, nil
-}
-
 // Status is the resolver for the status field.
 func (r *validatorResolver) Status(ctx context.Context, obj *nemeton.Validator) (model.ValidatorStatus, error) {
 	panic(fmt.Errorf("not implemented: Status - status"))
@@ -306,3 +301,13 @@ type (
 	tasksResolver     struct{ *Resolver }
 	validatorResolver struct{ *Resolver }
 )
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *validatorResolver) RPCEndpoint(ctx context.Context, obj *nemeton.Validator) (*url.URL, error) {
+	return obj.RPCEndpoint, nil
+}


### PR DESCRIPTION
#### Register RPC endpoint

New mutation has been created to register the validator's RPC endpoint URL. 
```graphql
"""
Emit a `RegisterRPCEndpointEvent` in the system to register RPC node url for the given druid validator.

Through the event handling logic, the validator will be fulfilled with his RPC endpoint url and task completed with points
attribution if still in progress. If event is submitted multiple time, RPC endpoint is updated.
"""
registerRPCEndpoint(
    """
    The validator moniker that will register the RPC endpoint.
    """
    validator: ValoperAddress!

    """
    The RPC endpoint url of validator.
    """
    url: URI!
): Void @auth
```

On mutation called, a new event is emitted to register the RPC endpoint. Event will register the endpoint on a new `rpcEndpoint` field and assign rewards (only once if it's launch in the task and phase time). If the event is re-emit, endpoint url is updated but point is not attributed. 

Since register rpc endpoint is a manually and controlled task, if the mutation is called outside of phase and task time, the endpoint is still updated but no rewards is given (it's allow update later the rpc endpoint, without rewarding).