### PR TITLE
Feat/register validator

### DIFF
--- a/app/actor/graphql/actor.go
+++ b/app/actor/graphql/actor.go
@@ -13,11 +13,12 @@ type Actor struct {
 	mongoURI   string
 	dbName     string
 	eventStore *actor.PID
+	grpcClient *actor.PID
 	bearer     *string
 	srv        *server
 }
 
-func NewActor(httpAddr, mongoURI, dbName string, eventStore *actor.PID, bearer *string) *Actor {
+func NewActor(httpAddr, mongoURI, dbName string, eventStore, grpcClient *actor.PID, bearer *string) *Actor {
 	return &Actor{
 		addr:       httpAddr,
 		mongoURI:   mongoURI,

--- a/app/actor/graphql/actor.go
+++ b/app/actor/graphql/actor.go
@@ -24,6 +24,7 @@ func NewActor(httpAddr, mongoURI, dbName string, eventStore, grpcClient *actor.P
 		mongoURI:   mongoURI,
 		dbName:     dbName,
 		eventStore: eventStore,
+		grpcClient: grpcClient,
 		bearer:     bearer,
 	}
 }
@@ -38,7 +39,7 @@ func (a *Actor) Receive(ctx actor.Context) {
 }
 
 func (a *Actor) handleStart(ctx actor.Context) {
-	graphqlServer, err := NewGraphQLServer(context.Background(), ctx, a.mongoURI, a.dbName, a.eventStore, a.bearer)
+	graphqlServer, err := NewGraphQLServer(context.Background(), ctx, a.mongoURI, a.dbName, a.eventStore, a.grpcClient, a.bearer)
 	if err != nil {
 		log.Fatal().Err(err).Str("db", a.dbName).Msg("❌ Couldn't create graphql server")
 	}

--- a/app/actor/graphql/graphql.go
+++ b/app/actor/graphql/graphql.go
@@ -21,7 +21,7 @@ func NewGraphQLServer(
 	ctx context.Context,
 	actorCTX actor.Context,
 	mongoURI, db string,
-	eventStore *actor.PID,
+	eventStore, grpcClient *actor.PID,
 	bearer *string,
 ) (*handler.Server, error) {
 	store, err := nemeton.NewStore(ctx, mongoURI, db)
@@ -29,7 +29,7 @@ func NewGraphQLServer(
 		return nil, err
 	}
 
-	cfg := generated.Config{Resolvers: graphql.NewResolver(actorCTX, store, keybase.NewClient(), eventStore)}
+	cfg := generated.Config{Resolvers: graphql.NewResolver(actorCTX, store, keybase.NewClient(), eventStore, grpcClient)}
 	cfg.Directives.Auth = func(ctx context.Context, obj interface{}, next graphql2.Resolver) (interface{}, error) {
 		if err := Authorize(ctx, bearer); err != nil {
 			return nil, err

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -148,8 +148,8 @@ func (a *Actor) handleNewBlockEvent(data map[string]interface{}) {
 func (a *Actor) handleGenTXSubmittedEvent(when time.Time, data map[string]interface{}) {
 	log.Info().Interface("event", data).Msg("Handle GenTXSubmitted event")
 
-	e, err := graphql.Unmarshall(data)
-	if err != nil {
+	e := &graphql.GenTXSubmittedEvent{}
+	if err := e.Unmarshall(data); err != nil {
 		log.Panic().Err(err).Msg("❌ Failed unmarshall event to GenTXSubmitted")
 		return
 	}

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -87,6 +87,8 @@ func (a *Actor) receiveNewEvent(e event.Event) {
 		a.handleNewBlockEvent(e.Data)
 	case graphql.GenTXSubmittedEventType:
 		a.handleGenTXSubmittedEvent(e.Date, e.Data)
+	case graphql.ValidatorRegisteredEventType:
+		a.handleValidatorRegisteredEvent(e.Data)
 	case tweet.NewTweetEventType:
 		a.handleNewTweetEvent(e.Date, e.Data)
 	case graphql.RegisterRPCEndpointEventType:
@@ -151,7 +153,7 @@ func (a *Actor) handleGenTXSubmittedEvent(when time.Time, data map[string]interf
 	log.Info().Interface("event", data).Msg("Handle GenTXSubmitted event")
 
 	e := &graphql.GenTXSubmittedEvent{}
-	if err := e.Unmarshall(data); err != nil {
+	if err := e.Unmarshal(data); err != nil {
 		log.Panic().Err(err).Msg("❌ Failed unmarshall event to GenTXSubmitted")
 		return
 	}
@@ -163,6 +165,29 @@ func (a *Actor) handleGenTXSubmittedEvent(when time.Time, data map[string]interf
 
 	if err := a.store.CreateGentxValidator(context.Background(), when, msgCreateVal, e.Discord, e.Country, e.Twitter); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't create validator")
+	}
+}
+
+func (a *Actor) handleValidatorRegisteredEvent(data map[string]interface{}) {
+	log.Info().Interface("event", data).Msg("Handle ValidatorRegistered event")
+
+	e := &graphql.ValidatorRegisteredEvent{}
+	if err := e.Unmarshal(data); err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshall event to ValidatorRegistered")
+		return
+	}
+
+	if err := a.store.RegisterValidator(
+		context.Background(),
+		e.Valoper,
+		e.Delegator,
+		e.Valcons,
+		e.Description,
+		e.Discord,
+		e.Country,
+		e.Twitter,
+	); err != nil {
+		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register validator")
 	}
 }
 

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -102,9 +102,9 @@ func (a *Actor) receiveNewEvent(e event.Event) {
 }
 
 func (a *Actor) handleNewBlockEvent(data map[string]interface{}) {
-	e, err := synchronization.Unmarshall(data)
-	if err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall event to NewBlockEvent")
+	e := &synchronization.NewBlockEvent{}
+	if err := e.Unmarshal(data); err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshal event to NewBlockEvent")
 		return
 	}
 
@@ -154,13 +154,13 @@ func (a *Actor) handleGenTXSubmittedEvent(when time.Time, data map[string]interf
 
 	e := &graphql.GenTXSubmittedEvent{}
 	if err := e.Unmarshal(data); err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall event to GenTXSubmitted")
+		log.Panic().Err(err).Msg("❌ Failed unmarshal event to GenTXSubmitted")
 		return
 	}
 
 	msgCreateVal, err := util.ParseGenTX(e.GenTX)
 	if err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall gentx")
+		log.Panic().Err(err).Msg("❌ Failed unmarshal gentx")
 	}
 
 	if err := a.store.CreateGentxValidator(context.Background(), when, msgCreateVal, e.Discord, e.Country, e.Twitter); err != nil {
@@ -173,7 +173,7 @@ func (a *Actor) handleValidatorRegisteredEvent(data map[string]interface{}) {
 
 	e := &graphql.ValidatorRegisteredEvent{}
 	if err := e.Unmarshal(data); err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall event to ValidatorRegistered")
+		log.Panic().Err(err).Msg("❌ Failed unmarshal event to ValidatorRegistered")
 		return
 	}
 
@@ -194,9 +194,9 @@ func (a *Actor) handleValidatorRegisteredEvent(data map[string]interface{}) {
 func (a *Actor) handleNewTweetEvent(when time.Time, data map[string]interface{}) {
 	log.Info().Interface("event", data).Msg("Handle NewTweet event")
 
-	e, err := tweet.Unmarshall(data)
-	if err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall event to NewTweetEvent")
+	e := &tweet.NewTweetEvent{}
+	if err := e.Unmarshal(data); err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshal event to NewTweetEvent")
 		return
 	}
 	phase := a.store.GetCurrentPhaseAt(when)
@@ -235,9 +235,9 @@ func (a *Actor) handlePhaseStarted(phase *nemeton.Phase) {
 func (a *Actor) handleRegisterRPCEndpointEvent(when time.Time, data map[string]interface{}) {
 	log.Info().Interface("event", data).Msg("Handle RegisterRPC event")
 
-	e, err := graphql.UnmarshallRegisterRPCEndpointEvent(data)
-	if err != nil {
-		log.Panic().Err(err).Msg("❌ Failed unmarshall event to RegisterRPCEndpointEvent")
+	e := &graphql.RegisterRPCEndpointEvent{}
+	if err := e.Unmarshal(data); err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshal event to RegisterRPCEndpointEvent")
 		return
 	}
 

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"okp4/nemeton-leaderboard/app/util"
+
 	"okp4/nemeton-leaderboard/graphql"
 
 	"okp4/nemeton-leaderboard/app/actor/synchronization"
@@ -154,7 +156,12 @@ func (a *Actor) handleGenTXSubmittedEvent(when time.Time, data map[string]interf
 		return
 	}
 
-	if err := a.store.CreateValidator(context.Background(), when, e.Discord, e.Country, e.Twitter, e.GenTX); err != nil {
+	msgCreateVal, err := util.ParseGenTX(e.GenTX)
+	if err != nil {
+		log.Panic().Err(err).Msg("❌ Failed unmarshall gentx")
+	}
+
+	if err := a.store.CreateGentxValidator(context.Background(), when, msgCreateVal, e.Discord, e.Country, e.Twitter); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't create validator")
 	}
 }

--- a/app/actor/synchronization/actor.go
+++ b/app/actor/synchronization/actor.go
@@ -18,15 +18,14 @@ import (
 const ownerOffset = "block-synchronization"
 
 type Actor struct {
-	context         context.Context
-	grpcClientProps *actor.Props
-	grpcClient      *actor.PID
-	eventStore      *actor.PID
-	offsetStore     *offset.Store
-	currentBlock    int64
+	context      context.Context
+	grpcClient   *actor.PID
+	eventStore   *actor.PID
+	offsetStore  *offset.Store
+	currentBlock int64
 }
 
-func NewActor(grpcClientProps *actor.Props, eventStore *actor.PID, mongoURI, dbName string) (*Actor, error) {
+func NewActor(eventStore, grpcClient *actor.PID, mongoURI, dbName string) (*Actor, error) {
 	ctx := context.Background()
 	store, err := offset.NewStore(ctx, mongoURI, dbName, ownerOffset)
 	if err != nil {
@@ -43,12 +42,11 @@ func NewActor(grpcClientProps *actor.Props, eventStore *actor.PID, mongoURI, dbN
 	}
 
 	return &Actor{
-		context:         ctx,
-		grpcClientProps: grpcClientProps,
-		grpcClient:      nil,
-		eventStore:      eventStore,
-		offsetStore:     store,
-		currentBlock:    currentBlock,
+		context:      ctx,
+		grpcClient:   grpcClient,
+		eventStore:   eventStore,
+		offsetStore:  store,
+		currentBlock: currentBlock,
 	}, nil
 }
 
@@ -56,8 +54,6 @@ func (a *Actor) Receive(ctx actor.Context) {
 	switch ctx.Message().(type) {
 	case *actor.Started:
 		log.Info().Msg("🔁 Start block syncing")
-
-		a.grpcClient = ctx.Spawn(a.grpcClientProps)
 
 		err := a.catchUpSyncBlocks(ctx)
 		if err != nil {

--- a/app/actor/synchronization/actor.go
+++ b/app/actor/synchronization/actor.go
@@ -154,7 +154,7 @@ func (a *Actor) publishEvent(ctx actor.Context, block *tmservice.Block) error {
 		Signatures: block.LastCommit.Signatures,
 	}
 
-	blockData, err := blockEvent.Marshall()
+	blockData, err := blockEvent.Marshal()
 	if err != nil {
 		return err
 	}

--- a/app/actor/synchronization/event.go
+++ b/app/actor/synchronization/event.go
@@ -15,7 +15,7 @@ type NewBlockEvent struct {
 	Signatures []types.CommitSig `json:"signatures"`
 }
 
-func (e *NewBlockEvent) Marshall() (map[string]interface{}, error) {
+func (e *NewBlockEvent) Marshal() (map[string]interface{}, error) {
 	var event map[string]interface{}
 	data, err := json.Marshal(&e)
 	if err != nil {
@@ -25,12 +25,11 @@ func (e *NewBlockEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func Unmarshall(data map[string]interface{}) (*NewBlockEvent, error) {
-	var event *NewBlockEvent
+func (e *NewBlockEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	err = json.Unmarshal(d, &event)
-	return event, err
+
+	return json.Unmarshal(d, e)
 }

--- a/app/actor/tweet/event.go
+++ b/app/actor/tweet/event.go
@@ -15,7 +15,7 @@ type NewTweetEvent struct {
 	User      User      `json:"user"`
 }
 
-func (e *NewTweetEvent) Marshall() (map[string]interface{}, error) {
+func (e *NewTweetEvent) Marshal() (map[string]interface{}, error) {
 	var event map[string]interface{}
 	data, err := json.Marshal(&e)
 	if err != nil {
@@ -25,12 +25,11 @@ func (e *NewTweetEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func Unmarshall(data map[string]interface{}) (*NewTweetEvent, error) {
-	var event *NewTweetEvent
+func (e *NewTweetEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	err = json.Unmarshal(d, &event)
-	return event, err
+
+	return json.Unmarshal(d, e)
 }

--- a/app/actor/tweet/search.go
+++ b/app/actor/tweet/search.go
@@ -167,7 +167,7 @@ func (a *SearchActor) handleTweets(ctx actor.Context, tweets *Response) {
 			User:      author,
 		}
 
-		eventData, err := e.Marshall()
+		eventData, err := e.Marshal()
 		if err != nil {
 			log.Err(err).Msg("❌ Failed to marshall event to map interface")
 			return

--- a/app/message/message.go
+++ b/app/message/message.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
+	"github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -34,6 +36,14 @@ type GetLatestBlock struct{}
 
 type GetBlockResponse struct {
 	Block *tmservice.Block
+}
+
+type GetValidator struct {
+	Valoper types.ValAddress
+}
+
+type GetValidatorResponse struct {
+	Validator *stakingtypes.Validator
 }
 
 // SyncBlock used for ask synchronization to request new block on chain.

--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -313,6 +313,24 @@ func (s *Store) CreateGentxValidator(
 	return err
 }
 
+func (s *Store) RegisterValidator(
+	ctx context.Context,
+	valoper types.ValAddress,
+	delegator types.AccAddress,
+	valcons types.ConsAddress,
+	description stakingtypes.Description,
+	discord, country string,
+	twitter *string,
+) error {
+	validator, err := NewValidator(valoper, delegator, valcons, description, discord, country, twitter)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.Collection(validatorsCollectionName).InsertOne(ctx, validator)
+	return err
+}
+
 func (s *Store) RegisterValidatorRPC(ctx context.Context, when time.Time, validator types.ValAddress, rpc *url.URL) error {
 	filter := bson.M{"valoper": validator}
 	_, err := s.db.Collection(validatorsCollectionName).UpdateOne(ctx,

--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -10,6 +10,7 @@ import (
 	"okp4/nemeton-leaderboard/app/util"
 
 	"github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -278,19 +279,14 @@ func makeBoardFilter(search *string, after *Cursor) bson.M {
 	return filter
 }
 
-func (s *Store) CreateValidator(
+func (s *Store) CreateGentxValidator(
 	ctx context.Context,
 	createdAt time.Time,
+	msgCreateVal *stakingtypes.MsgCreateValidator,
 	discord, country string,
 	twitter *string,
-	genTX map[string]interface{},
 ) error {
-	msgCreateVal, err := ParseGenTX(genTX)
-	if err != nil {
-		return err
-	}
-
-	validator, err := MakeValidator(msgCreateVal, discord, country, twitter)
+	validator, err := MakeValidatorFromMsg(msgCreateVal, discord, country, twitter)
 	if err != nil {
 		return err
 	}

--- a/app/nemeton/validator.go
+++ b/app/nemeton/validator.go
@@ -28,7 +28,7 @@ type Validator struct {
 	Tasks       map[int]map[string]TaskState `bson:"tasks"`
 }
 
-func MakeValidator(createMsg *stakingtypes.MsgCreateValidator, discord, country string, twitter *string) (*Validator, error) {
+func MakeValidatorFromMsg(createMsg *stakingtypes.MsgCreateValidator, discord, country string, twitter *string) (*Validator, error) {
 	valoper, err := types.ValAddressFromBech32(createMsg.ValidatorAddress)
 	if err != nil {
 		return nil, err

--- a/app/nemeton/validator.go
+++ b/app/nemeton/validator.go
@@ -38,40 +38,54 @@ func MakeValidatorFromMsg(createMsg *stakingtypes.MsgCreateValidator, discord, c
 		return nil, err
 	}
 
-	var website *url.URL
-	if len(createMsg.Description.Website) > 0 {
-		website, err = url.Parse(createMsg.Description.Website)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	pubkey, ok := createMsg.Pubkey.GetCachedValue().(cryptotypes.PubKey)
 	if !ok {
 		return nil, fmt.Errorf("couldn't parse public key")
 	}
 
-	var identity *string
-	if len(createMsg.Description.Identity) > 0 {
-		identity = &createMsg.Description.Identity
+	return NewValidator(valoper, delegator, types.GetConsAddress(pubkey), createMsg.Description, discord, country, twitter)
+}
+
+func NewValidator(
+	valoper types.ValAddress,
+	delegator types.AccAddress,
+	valcons types.ConsAddress,
+	description stakingtypes.Description,
+	discord, country string,
+	twitter *string,
+) (*Validator, error) {
+	var website *url.URL
+	var err error
+	if len(description.Website) > 0 {
+		website, err = url.Parse(description.Website)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	var identity *string
+	if len(description.Identity) > 0 {
+		identity = &description.Identity
+	}
+
 	var details *string
-	if len(createMsg.Description.Details) > 0 {
-		details = &createMsg.Description.Details
+	if len(description.Details) > 0 {
+		details = &description.Details
 	}
 
 	return &Validator{
-		Moniker:   createMsg.Description.Moniker,
+		Moniker:   description.Moniker,
 		Identity:  identity,
 		Details:   details,
 		Valoper:   valoper,
 		Delegator: delegator,
-		Valcons:   types.GetConsAddress(pubkey),
+		Valcons:   valcons,
 		Twitter:   twitter,
 		Website:   website,
 		Discord:   discord,
 		Country:   country,
 		Status:    "inactive",
+		Tasks:     map[int]map[string]TaskState{},
 	}, nil
 }
 

--- a/app/util/gentx.go
+++ b/app/util/gentx.go
@@ -1,4 +1,4 @@
-package nemeton
+package util
 
 import (
 	"encoding/json"

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -5,10 +5,12 @@ import (
 	"net/url"
 
 	"github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 const (
 	GenTXSubmittedEventType      = "gentx-submitted"
+	ValidatorRegisteredEventType = "validator-registered"
 	RegisterRPCEndpointEventType = "register-rpc-endpoint"
 )
 
@@ -29,14 +31,40 @@ func (e *GenTXSubmittedEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func Unmarshall(data map[string]interface{}) (*GenTXSubmittedEvent, error) {
-	var event *GenTXSubmittedEvent
+func (e *GenTXSubmittedEvent) Unmarshall(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(d, e)
+}
+
+type ValidatorRegisteredEvent struct {
+	Twitter   *string                `json:"twitter,omitempty"`
+	Discord   string                 `json:"discord"`
+	Country   string                 `json:"country"`
+	Delegator types.AccAddress       `json:"delegator"`
+	Validator stakingtypes.Validator `json:"validator"`
+}
+
+func (e *ValidatorRegisteredEvent) Marshall() (map[string]interface{}, error) {
+	var event map[string]interface{}
+	data, err := json.Marshal(&e)
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(d, &event)
+	err = json.Unmarshal(data, &event)
 	return event, err
+}
+
+func (e *ValidatorRegisteredEvent) Unmarshall(data map[string]interface{}) error {
+	d, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(d, e)
 }
 
 type RegisterRPCEndpointEvent struct {

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -21,7 +21,7 @@ type GenTXSubmittedEvent struct {
 	GenTX   map[string]interface{} `json:"gentx"`
 }
 
-func (e *GenTXSubmittedEvent) Marshall() (map[string]interface{}, error) {
+func (e *GenTXSubmittedEvent) Marshal() (map[string]interface{}, error) {
 	var event map[string]interface{}
 	data, err := json.Marshal(&e)
 	if err != nil {
@@ -31,7 +31,7 @@ func (e *GenTXSubmittedEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func (e *GenTXSubmittedEvent) Unmarshall(data map[string]interface{}) error {
+func (e *GenTXSubmittedEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -41,14 +41,16 @@ func (e *GenTXSubmittedEvent) Unmarshall(data map[string]interface{}) error {
 }
 
 type ValidatorRegisteredEvent struct {
-	Twitter   *string                `json:"twitter,omitempty"`
-	Discord   string                 `json:"discord"`
-	Country   string                 `json:"country"`
-	Delegator types.AccAddress       `json:"delegator"`
-	Validator stakingtypes.Validator `json:"validator"`
+	Twitter     *string                  `json:"twitter,omitempty"`
+	Discord     string                   `json:"discord"`
+	Country     string                   `json:"country"`
+	Valoper     types.ValAddress         `json:"valoper"`
+	Delegator   types.AccAddress         `json:"delegator"`
+	Valcons     types.ConsAddress        `json:"valcons"`
+	Description stakingtypes.Description `json:"description"`
 }
 
-func (e *ValidatorRegisteredEvent) Marshall() (map[string]interface{}, error) {
+func (e *ValidatorRegisteredEvent) Marshal() (map[string]interface{}, error) {
 	var event map[string]interface{}
 	data, err := json.Marshal(&e)
 	if err != nil {
@@ -58,7 +60,7 @@ func (e *ValidatorRegisteredEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func (e *ValidatorRegisteredEvent) Unmarshall(data map[string]interface{}) error {
+func (e *ValidatorRegisteredEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -74,7 +74,7 @@ type RegisterRPCEndpointEvent struct {
 	URL       *url.URL         `json:"url"`
 }
 
-func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {
+func (e *RegisterRPCEndpointEvent) Marshal() (map[string]interface{}, error) {
 	var event map[string]interface{}
 	data, err := json.Marshal(&e)
 	if err != nil {
@@ -84,12 +84,11 @@ func (e *RegisterRPCEndpointEvent) Marshall() (map[string]interface{}, error) {
 	return event, err
 }
 
-func UnmarshallRegisterRPCEndpointEvent(data map[string]interface{}) (*RegisterRPCEndpointEvent, error) {
-	var event *RegisterRPCEndpointEvent
+func (e *RegisterRPCEndpointEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	err = json.Unmarshal(d, &event)
-	return event, err
+
+	return json.Unmarshal(d, e)
 }

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -8,13 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"okp4/nemeton-leaderboard/app/nemeton"
-	"okp4/nemeton-leaderboard/graphql/model"
-	"okp4/nemeton-leaderboard/graphql/scalar"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"okp4/nemeton-leaderboard/app/nemeton"
+	"okp4/nemeton-leaderboard/graphql/model"
+	"okp4/nemeton-leaderboard/graphql/scalar"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
@@ -77,6 +78,7 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		RegisterRPCEndpoint  func(childComplexity int, validator types.ValAddress, url *url.URL) int
+		RegisterValidator    func(childComplexity int, twitter *string, discord string, country string, validator types.ValAddress) int
 		SubmitValidatorGenTx func(childComplexity int, twitter *string, discord string, country string, gentx map[string]interface{}) int
 	}
 
@@ -177,6 +179,7 @@ type IdentityResolver interface {
 }
 type MutationResolver interface {
 	SubmitValidatorGenTx(ctx context.Context, twitter *string, discord string, country string, gentx map[string]interface{}) (*string, error)
+	RegisterValidator(ctx context.Context, twitter *string, discord string, country string, validator types.ValAddress) (*string, error)
 	RegisterRPCEndpoint(ctx context.Context, validator types.ValAddress, url *url.URL) (*string, error)
 }
 type PhaseResolver interface {
@@ -291,6 +294,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.RegisterRPCEndpoint(childComplexity, args["validator"].(types.ValAddress), args["url"].(*url.URL)), true
+
+	case "Mutation.registerValidator":
+		if e.complexity.Mutation.RegisterValidator == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_registerValidator_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RegisterValidator(childComplexity, args["twitter"].(*string), args["discord"].(string), args["country"].(string), args["validator"].(types.ValAddress)), true
 
 	case "Mutation.submitValidatorGenTX":
 		if e.complexity.Mutation.SubmitValidatorGenTx == nil {
@@ -962,6 +977,33 @@ type Mutation {
     ): Void @auth
 
     """
+    Emit a ` + "`" + `ValidatorRegisteredEvent` + "`" + ` in the system carrying information related to the integration of a validator post genesis.
+
+    The validator will be integrated into the leaderboard with its on chain information, past tasks will be considered not done.
+    """
+    registerValidator(
+        """
+        The validator twitter account.
+        """
+        twitter: String
+
+        """
+        The validator discord account.
+        """
+        discord: String!
+
+        """
+        The validator country.
+        """
+        country: String!
+
+        """
+        The validator address, used to retrieve its information on chain.
+        """
+        validator: ValoperAddress!
+    ): Void @auth
+
+    """
     Emit a ` + "`" + `RegisterRPCEndpointEvent` + "`" + ` in the system to register RPC node url for the given druid validator.
 
     Through the event handling logic, the validator will be fulfilled with his RPC endpoint url and task completed with points
@@ -1407,6 +1449,48 @@ func (ec *executionContext) field_Mutation_registerRPCEndpoint_args(ctx context.
 		}
 	}
 	args["url"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_registerValidator_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["twitter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("twitter"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["twitter"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["discord"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("discord"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["discord"] = arg1
+	var arg2 string
+	if tmp, ok := rawArgs["country"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("country"))
+		arg2, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["country"] = arg2
+	var arg3 types.ValAddress
+	if tmp, ok := rawArgs["validator"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validator"))
+		arg3, err = ec.unmarshalNValoperAddress2githubᚗcomᚋcosmosᚋcosmosᚑsdkᚋtypesᚐValAddress(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["validator"] = arg3
 	return args, nil
 }
 
@@ -2063,6 +2147,78 @@ func (ec *executionContext) fieldContext_Mutation_submitValidatorGenTX(ctx conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_submitValidatorGenTX_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_registerValidator(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_registerValidator(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().RegisterValidator(rctx, fc.Args["twitter"].(*string), fc.Args["discord"].(string), fc.Args["country"].(string), fc.Args["validator"].(types.ValAddress))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.Auth == nil {
+				return nil, errors.New("directive auth is not implemented")
+			}
+			return ec.directives.Auth(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*string); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOVoid2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_registerValidator(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Void does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_registerValidator_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -7155,7 +7311,6 @@ func (ec *executionContext) _Identity(ctx context.Context, sel ast.SelectionSet,
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7219,6 +7374,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_submitValidatorGenTX(ctx, field)
+			})
+
+		case "registerValidator":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_registerValidator(ctx, field)
 			})
 
 		case "registerRPCEndpoint":
@@ -7425,7 +7586,6 @@ func (ec *executionContext) _Phase(ctx context.Context, sel ast.SelectionSet, ob
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7466,7 +7626,6 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "ongoing":
 			field := field
@@ -7486,7 +7645,6 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "finished":
 			field := field
@@ -7506,7 +7664,6 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "current":
 			field := field
@@ -7523,7 +7680,6 @@ func (ec *executionContext) _Phases(ctx context.Context, sel ast.SelectionSet, o
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7856,7 +8012,6 @@ func (ec *executionContext) _Tasks(ctx context.Context, sel ast.SelectionSet, ob
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -7897,7 +8052,6 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "moniker":
 
@@ -7921,7 +8075,6 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "details":
 
@@ -7985,7 +8138,6 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "points":
 
@@ -8012,7 +8164,6 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		case "missedBlocks":
 			field := field
@@ -8032,7 +8183,6 @@ func (ec *executionContext) _Validator(ctx context.Context, sel ast.SelectionSet
 
 			out.Concurrently(i, func() graphql.Marshaler {
 				return innerFunc(ctx)
-
 			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"okp4/nemeton-leaderboard/app/nemeton"
 	"strconv"
+
+	"okp4/nemeton-leaderboard/app/nemeton"
 )
 
 // Represents a blockchain block range.

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -20,18 +20,20 @@ type Resolver struct {
 	store         *nemeton.Store
 	keybaseClient *keybase.Client
 	eventStore    *actor.PID
+	grpcClient    *actor.PID
 }
 
 func NewResolver(
 	ctx actor.Context,
 	store *nemeton.Store,
 	keybaseClient *keybase.Client,
-	eventStore *actor.PID,
+	eventStore, grpcClient *actor.PID,
 ) *Resolver {
 	return &Resolver{
 		actorCTX:      ctx,
 		store:         store,
 		keybaseClient: keybaseClient,
 		eventStore:    eventStore,
+		grpcClient:    grpcClient,
 	}
 }

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -163,6 +163,11 @@ type Mutation {
         country: String!
 
         """
+        The delegator address who created the validator.
+        """
+        delegator: AccAddress!
+
+        """
         The validator address, used to retrieve its information on chain.
         """
         validator: ValoperAddress!

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -142,6 +142,33 @@ type Mutation {
     ): Void @auth
 
     """
+    Emit a `ValidatorRegisteredEvent` in the system carrying information related to the integration of a validator post genesis.
+
+    The validator will be integrated into the leaderboard with its on chain information, past tasks will be considered not done.
+    """
+    registerValidator(
+        """
+        The validator twitter account.
+        """
+        twitter: String
+
+        """
+        The validator discord account.
+        """
+        discord: String!
+
+        """
+        The validator country.
+        """
+        country: String!
+
+        """
+        The validator address, used to retrieve its information on chain.
+        """
+        validator: ValoperAddress!
+    ): Void @auth
+
+    """
     Emit a `RegisterRPCEndpointEvent` in the system to register RPC node url for the given druid validator.
 
     Through the event handling logic, the validator will be fulfilled with his RPC endpoint url and task completed with points

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -126,7 +126,7 @@ func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator ty
 		Validator: validator,
 		URL:       url,
 	}
-	rawEvt, err := evt.Marshall()
+	rawEvt, err := evt.Marshal()
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -57,6 +57,11 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 	return nil, nil
 }
 
+// RegisterValidator is the resolver for the registerValidator field.
+func (r *mutationResolver) RegisterValidator(ctx context.Context, twitter *string, discord string, country string, validator types.ValAddress) (*string, error) {
+	panic(fmt.Errorf("not implemented: RegisterValidator - registerValidator"))
+}
+
 // RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.
 func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator types.ValAddress, url *url.URL) (*string, error) {
 	evt := RegisterRPCEndpointEvent{

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"okp4/nemeton-leaderboard/app/event"
 	"okp4/nemeton-leaderboard/app/message"
@@ -16,6 +17,7 @@ import (
 	"okp4/nemeton-leaderboard/graphql/model"
 
 	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog/log"
 )
 
 // Picture is the resolver for the picture field.
@@ -58,8 +60,54 @@ func (r *mutationResolver) SubmitValidatorGenTx(ctx context.Context, twitter *st
 }
 
 // RegisterValidator is the resolver for the registerValidator field.
-func (r *mutationResolver) RegisterValidator(ctx context.Context, twitter *string, discord string, country string, validator types.ValAddress) (*string, error) {
-	panic(fmt.Errorf("not implemented: RegisterValidator - registerValidator"))
+func (r *mutationResolver) RegisterValidator(ctx context.Context, twitter *string, discord string, country string, delegator types.AccAddress, validator types.ValAddress) (*string, error) {
+	res, err := r.actorCTX.RequestFuture(
+		r.grpcClient,
+		&message.GetValidator{
+			Valoper: validator,
+		},
+		5*time.Second,
+	).Result()
+	if err != nil {
+		log.Err(err).Str("valoper", validator.String()).Msg("🤕 Couldn't fetch validator")
+		return nil, err
+	}
+
+	val, ok := res.(*message.GetValidatorResponse)
+	if !ok {
+		err := fmt.Errorf("cannot read grpc validator response")
+		log.Err(err).Str("valoper", validator.String()).Msg("🤕 Couldn't fetch validator")
+		return nil, err
+	}
+
+	if val.Validator == nil {
+		err := fmt.Errorf("could not find validator")
+		log.Err(err).Str("valoper", validator.String()).Msg("🤕 Couldn't fetch validator")
+		return nil, err
+	}
+
+	evt := ValidatorRegisteredEvent{
+		Twitter:   twitter,
+		Discord:   discord,
+		Country:   country,
+		Delegator: delegator,
+		Validator: *val.Validator,
+	}
+	rawEvt, err := evt.Marshall()
+	if err != nil {
+		return nil, err
+	}
+
+	r.actorCTX.Send(
+		r.eventStore,
+		&message.PublishEventMessage{
+			Event: event.NewEvent(
+				ValidatorRegisteredEventType,
+				rawEvt,
+			),
+		},
+	)
+	return nil, nil
 }
 
 // RegisterRPCEndpoint is the resolver for the registerRPCEndpoint field.


### PR DESCRIPTION
Add the `registerValidator` mutation to integrate a validator into the leaderboard post genesis. The validator details are fetched on chain before packed in an event.