### PR TITLE
Feat/manual task completion

### DIFF
--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -283,6 +283,6 @@ func (a *Actor) handleTaskCompletedEvent(when time.Time, data map[string]interfa
 	}
 
 	if err := a.store.ManualCompleteTask(a.ctx, e.Validator, when, e.Phase, e.Task, e.Points); err != nil {
-		log.Err(err).Interface("data", data).Msg("🤕 Couldn't register/update validator rpc endpoint")
+		log.Err(err).Interface("data", data).Msg("🤕 Couldn't manually complete task")
 	}
 }

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -13,6 +13,7 @@ const (
 	ValidatorRegisteredEventType = "validator-registered"
 	ValidatorUpdatedEventType    = "validator-updated"
 	RegisterRPCEndpointEventType = "register-rpc-endpoint"
+	TaskCompletedEventType       = "task-completed"
 )
 
 type GenTXSubmittedEvent struct {
@@ -115,6 +116,32 @@ func (e *RegisterRPCEndpointEvent) Marshal() (map[string]interface{}, error) {
 }
 
 func (e *RegisterRPCEndpointEvent) Unmarshal(data map[string]interface{}) error {
+	d, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(d, e)
+}
+
+type TaskCompletedEvent struct {
+	Validator types.ValAddress `json:"validator"`
+	Phase     int              `json:"phase"`
+	Task      string           `json:"task"`
+	Points    *uint64          `json:"points,omitempty"`
+}
+
+func (e *TaskCompletedEvent) Marshal() (map[string]interface{}, error) {
+	var event map[string]interface{}
+	data, err := json.Marshal(&e)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &event)
+	return event, err
+}
+
+func (e *TaskCompletedEvent) Unmarshal(data map[string]interface{}) error {
 	d, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -222,6 +222,35 @@ type Mutation {
         """
         url: URI!
     ): Void @auth
+
+    """
+    Emit a `TaskCompletedEvent` in the system carrying information related to the completion of a task.
+
+    The purpose is to manually attribute the points of a task, automated or not. This generic event doesn't carrying task specific context, prefer using more grained mutation to ensure any specific logic is executed, if applicable.
+
+    The event handling is idempotent, it ensures the task is completed and the points attributed once.
+    """
+    completeTask(
+        """
+        The validator who has completed the task.
+        """
+        validator: ValoperAddress!
+
+        """
+        The phase the task belongs to.
+        """
+        phase: Int!
+
+        """
+        The completed task.
+        """
+        task: ID!
+
+        """
+        The points to attribute, if applicable. The priority will be given to the static rewards amount specified in the task definition.
+        """
+        points: UInt64
+    ): Void @auth
 }
 
 """

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -157,7 +157,27 @@ func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator ty
 
 // CompleteTask is the resolver for the completeTask field.
 func (r *mutationResolver) CompleteTask(ctx context.Context, validator types.ValAddress, phase int, task string, points *uint64) (*string, error) {
-	panic(fmt.Errorf("not implemented: CompleteTask - completeTask"))
+	evt := &TaskCompletedEvent{
+		Validator: validator,
+		Phase:     phase,
+		Task:      task,
+		Points:    points,
+	}
+	rawEvt, err := evt.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	r.actorCTX.Send(
+		r.eventStore,
+		&message.PublishEventMessage{
+			Event: event.NewEvent(
+				TaskCompletedEventType,
+				rawEvt,
+			),
+		},
+	)
+	return nil, nil
 }
 
 // Blocks is the resolver for the blocks field.

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -155,6 +155,11 @@ func (r *mutationResolver) RegisterRPCEndpoint(ctx context.Context, validator ty
 	return nil, nil
 }
 
+// CompleteTask is the resolver for the completeTask field.
+func (r *mutationResolver) CompleteTask(ctx context.Context, validator types.ValAddress, phase int, task string, points *uint64) (*string, error) {
+	panic(fmt.Errorf("not implemented: CompleteTask - completeTask"))
+}
+
 // Blocks is the resolver for the blocks field.
 func (r *phaseResolver) Blocks(ctx context.Context, obj *nemeton.Phase) (*model.BlockRange, error) {
 	blocks, err := r.store.GetPhaseBlocks(ctx, obj.Number)


### PR DESCRIPTION
Add the `completeTask` mutation to manually pass a task to complete for a validator, automated or not.

It does not override a previous completion.

It allow setting rewards which will have the priority over an eventual task predefined rewards.

In case neither task predefined rewards nor mutation argument rewards are present, the task won't be completed.