### PR TITLE
🐛 Fix: stop mongo stream on crash

### DIFF
--- a/app/actor/event/store.go
+++ b/app/actor/event/store.go
@@ -81,5 +81,6 @@ func (a *StoreActor) handleSubscribeEvent(ctx actor.Context, msg *message.Subscr
 func (a *StoreActor) handleUnsubscribeEvent(ctx actor.Context, msg *message.UnsubscribeEventMessage) {
 	streamPID := a.streams[msg.PID.Address]
 	ctx.Stop(streamPID)
+	delete(a.streams, msg.PID.Address)
 	log.Info().Str("to", msg.PID.Address).Msg("®️ Event subscriber unsubscribed")
 }

--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -71,6 +71,9 @@ func (a *Actor) Receive(ctx actor.Context) {
 		a.receiveNewEvent(e.Event)
 	case *actor.Restarting, *actor.Stopping:
 		log.Info().Msg("✋ Stop looking new event")
+		ctx.Send(a.eventPID, &message.UnsubscribeEventMessage{
+			PID: ctx.Self(),
+		})
 		if err := a.offsetStore.Close(context.Background()); err != nil {
 			log.Err(err).Msg("❌ Couldn't properly close offset store")
 		}

--- a/app/message/message.go
+++ b/app/message/message.go
@@ -19,6 +19,10 @@ type SubscribeEventMessage struct {
 	From *primitive.ObjectID
 }
 
+type UnsubscribeEventMessage struct {
+	PID *actor.PID
+}
+
 type NewEventMessage struct {
 	Event event.Event
 }


### PR DESCRIPTION
Add a new Event `UnsubscribeEventMessage` to trigger when synchronization actor has been stopped. That avoid to keep the mongo stream open and reopened without close on synchronization actor restart.  

Fixes #32 