### PR TITLE
🗳️ Detect validator vote proposals

### DIFF
--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -138,6 +138,10 @@ func (a *Actor) handleNewBlockEvent(data map[string]interface{}) {
 		logger.Panic().Err(err).Msg("🤕 Failed update validator node setup task.")
 	}
 
+	if err := a.store.CompleteVoteProposalTask(a.ctx, e.Time, e.MsgVotes); err != nil {
+		logger.Panic().Err(err).Msg("🤕 Failed complete vote proposal task.")
+	}
+
 	if err := a.store.UpdatePhaseBlocks(a.ctx, e.Time, e.Height); err != nil {
 		logger.Panic().Err(err).Msg("🤕 Failed update phase block range.")
 	}

--- a/app/actor/synchronization/event.go
+++ b/app/actor/synchronization/event.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	types2 "github.com/cosmos/cosmos-sdk/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -14,7 +14,7 @@ type NewBlockEvent struct {
 	Height     int64             `json:"height"`
 	Time       time.Time         `json:"time"`
 	Signatures []types.CommitSig `json:"signatures"`
-	Msgs       []types2.Msg      `json:"msgs"`
+	MsgVotes   []v1.MsgVote      `json:"omitempty,msgVotes"`
 }
 
 func (e *NewBlockEvent) Marshal() (map[string]interface{}, error) {

--- a/app/actor/synchronization/event.go
+++ b/app/actor/synchronization/event.go
@@ -14,7 +14,7 @@ type NewBlockEvent struct {
 	Height     int64             `json:"height"`
 	Time       time.Time         `json:"time"`
 	Signatures []types.CommitSig `json:"signatures"`
-	MsgVotes   []v1.MsgVote      `json:"omitempty,msgVotes"`
+	MsgVotes   []v1.MsgVote      `json:"msgVotes,omitempty"`
 }
 
 func (e *NewBlockEvent) Marshal() (map[string]interface{}, error) {

--- a/app/actor/synchronization/event.go
+++ b/app/actor/synchronization/event.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	types2 "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -13,6 +14,7 @@ type NewBlockEvent struct {
 	Height     int64             `json:"height"`
 	Time       time.Time         `json:"time"`
 	Signatures []types.CommitSig `json:"signatures"`
+	Msgs       []types2.Msg      `json:"msgs"`
 }
 
 func (e *NewBlockEvent) Marshal() (map[string]interface{}, error) {

--- a/app/nemeton/bootstrap.go
+++ b/app/nemeton/bootstrap.go
@@ -191,6 +191,17 @@ Share the content links to botanik#4248 on Discord. Only one submission per drui
 			Description: "The third phase is all about token dynamics! Druids will engage in various node and community tasks with their precious tokens. Challenges will include some IBC-related tasks to open Nemeton to the interchain world...ime. Maintenance tasks and upgrades will be performed to test different kinds of state migrations.",
 			StartDate:   time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
 			EndDate:     time.Date(2023, time.February, 19, 23, 59, 59, 0, time.UTC),
+			Tasks: []Task{
+				makeVoteProposalTask(
+					"0",
+					"Vote for governance proposal to whitelist address for smart contract deployment",
+					"",
+					time.Date(2023, time.January, 2, 0, 0, 0, 0, time.UTC),     // TODO:⚠️ CHANGE DATE
+					time.Date(2023, time.January, 31, 23, 59, 59, 0, time.UTC), // TODO:⚠️ CHANGE DATE
+					1500,
+					1,
+				),
+			},
 		},
 	}
 }

--- a/app/nemeton/store.go
+++ b/app/nemeton/store.go
@@ -751,7 +751,7 @@ func (s *Store) CompleteVoteProposalTask(ctx context.Context, when time.Time, ms
 		return fmt.Errorf("could not retrieve linked proposal ID for task %s", task.ID)
 	}
 
-	addrs := make([]types.AccAddress, len(msgVotes))
+	addrs := make([]types.AccAddress, 0, len(msgVotes))
 	for _, vote := range msgVotes {
 		if vote.ProposalId == *proposalID {
 			addr, err := types.AccAddressFromBech32(vote.Voter)

--- a/app/nemeton/task.go
+++ b/app/nemeton/task.go
@@ -14,7 +14,7 @@ const (
 	TaskTypeVoteProposal = "vote-proposal"
 
 	taskParamMaxPoints  = "max-points"
-	taskParamProposalId = "proposal-id"
+	taskParamProposalID = "proposal-id"
 )
 
 type TaskState struct {
@@ -76,7 +76,7 @@ func (t Task) GetParamMaxPoints() *uint64 {
 }
 
 func (t Task) GetParamProposalID() *uint64 {
-	if v, ok := t.Params[taskParamProposalId]; ok {
+	if v, ok := t.Params[taskParamProposalID]; ok {
 		if proposalID, ok := v.(int64); ok {
 			p := uint64(proposalID)
 			return &p
@@ -141,6 +141,6 @@ func makeDashboardTask(id, name, description string, start, end time.Time, maxPo
 
 func makeVoteProposalTask(id, name, description string, start, end time.Time, rewards uint64, proposalID uint64) Task {
 	return makeTask(TaskTypeVoteProposal, id, name, description, start, end, &rewards, map[string]interface{}{
-		taskParamProposalId: proposalID,
+		taskParamProposalID: proposalID,
 	})
 }

--- a/app/nemeton/task.go
+++ b/app/nemeton/task.go
@@ -11,8 +11,10 @@ const (
 	TaskTypeRPC          = "rpc"
 	TaskTypeSnapshots    = "snapshots"
 	TaskTypeDashboard    = "dashboard"
+	TaskTypeVoteProposal = "vote-proposal"
 
-	taskParamMaxPoints = "max-points"
+	taskParamMaxPoints  = "max-points"
+	taskParamProposalId = "proposal-id"
 )
 
 type TaskState struct {
@@ -124,5 +126,11 @@ func makeSnapshotsTask(id, name, description string, start, end time.Time, rewar
 func makeDashboardTask(id, name, description string, start, end time.Time, maxPoints uint64) Task {
 	return makeTask(TaskTypeDashboard, id, name, description, start, end, nil, map[string]interface{}{
 		taskParamMaxPoints: maxPoints,
+	})
+}
+
+func makeVoteProposalTask(id, name, description string, start, end time.Time, rewards uint64, proposalID uint) Task {
+	return makeTask(TaskTypeVoteProposal, id, name, description, start, end, &rewards, map[string]interface{}{
+		taskParamProposalId: proposalID,
 	})
 }

--- a/app/nemeton/task.go
+++ b/app/nemeton/task.go
@@ -75,6 +75,16 @@ func (t Task) GetParamMaxPoints() *uint64 {
 	return nil
 }
 
+func (t Task) GetParamProposalID() *uint64 {
+	if v, ok := t.Params[taskParamProposalId]; ok {
+		if proposalID, ok := v.(int64); ok {
+			p := uint64(proposalID)
+			return &p
+		}
+	}
+	return nil
+}
+
 func makeTask(
 	ttype, id, name, description string,
 	start, end time.Time,
@@ -129,7 +139,7 @@ func makeDashboardTask(id, name, description string, start, end time.Time, maxPo
 	})
 }
 
-func makeVoteProposalTask(id, name, description string, start, end time.Time, rewards uint64, proposalID uint) Task {
+func makeVoteProposalTask(id, name, description string, start, end time.Time, rewards uint64, proposalID uint64) Task {
 	return makeTask(TaskTypeVoteProposal, id, name, description, start, end, &rewards, map[string]interface{}{
 		taskParamProposalId: proposalID,
 	})


### PR DESCRIPTION
#### 📝 Description 

In the future phase 3, validators will need to vote for governance proposals. To detect automatically their vote and attribute rewards, I have introduce the parsing of all transaction in each block to detect MsgVote transaction and keep it in block event. Then when event is handled, points could be attributed to validator if it's correspond the the needed proposal ID. 

#### ⚙️ Implementation 

Each block will be parsed to detect all MsgVote messages, only those messages are kept into event block through `msgVotes` attributes. 
When event is handled, we check if the vote is linked to the current task proposal id. Then the reward is attributed to the validator with his `delegator` address since vote is done by the validator delegator address. 

#### 🆕 EDIT

**I'v refactored the method to get the current phase and task at a given time to return all retrieved tasks instead of the first found. It's allow for the needs of this phase task to have two vote proposal task at the same time.**