### PR TITLE
feat: allow override completed task

### DIFF
--- a/app/actor/subscription/actor.go
+++ b/app/actor/subscription/actor.go
@@ -342,7 +342,7 @@ func (a *Actor) handleTaskCompletedEvent(data map[string]interface{}) {
 		return
 	}
 
-	if err := a.store.ManualCompleteTask(a.ctx, e.Validator, e.Phase, e.Task, e.Points); err != nil {
+	if err := a.store.ManualCompleteTask(a.ctx, e.Validator, e.Phase, e.Task, e.Points, e.Override); err != nil {
 		log.Err(err).Interface("data", data).Msg("🤕 Couldn't manually complete task")
 	}
 }

--- a/graphql/event.go
+++ b/graphql/event.go
@@ -182,6 +182,7 @@ type TaskCompletedEvent struct {
 	Phase     int              `json:"phase"`
 	Task      string           `json:"task"`
 	Points    *uint64          `json:"points,omitempty"`
+	Override  bool             `json:"override"`
 }
 
 func (e *TaskCompletedEvent) Marshal() (map[string]interface{}, error) {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"okp4/nemeton-leaderboard/app/nemeton"
 	"strconv"
+
+	"okp4/nemeton-leaderboard/app/nemeton"
 )
 
 // Represents the progress/result of a task assigned to a validator.

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -319,6 +319,11 @@ type Mutation {
         The points to attribute, if applicable. The priority will be given to the static rewards amount specified in the task definition.
         """
         points: UInt64
+
+        """
+        Allow updating points even if the task was already completed.
+        """
+        override: Boolean = False
     ): Void @auth
 
     """

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+
 	"okp4/nemeton-leaderboard/app/event"
 	"okp4/nemeton-leaderboard/app/message"
 	"okp4/nemeton-leaderboard/app/nemeton"
@@ -276,12 +277,13 @@ func (r *mutationResolver) RegisterDashboardURL(ctx context.Context, validator t
 }
 
 // CompleteTask is the resolver for the completeTask field.
-func (r *mutationResolver) CompleteTask(ctx context.Context, validator types.ValAddress, phase int, task string, points *uint64) (*string, error) {
+func (r *mutationResolver) CompleteTask(ctx context.Context, validator types.ValAddress, phase int, task string, points *uint64, override *bool) (*string, error) {
 	evt := &TaskCompletedEvent{
 		Validator: validator,
 		Phase:     phase,
 		Task:      task,
 		Points:    points,
+		Override:  override != nil && *override,
 	}
 	rawEvt, err := evt.Marshal()
 	if err != nil {
@@ -553,10 +555,12 @@ func (r *Resolver) Tasks() generated.TasksResolver { return &tasksResolver{r} }
 // Validator returns generated.ValidatorResolver implementation.
 func (r *Resolver) Validator() generated.ValidatorResolver { return &validatorResolver{r} }
 
-type identityResolver struct{ *Resolver }
-type mutationResolver struct{ *Resolver }
-type phaseResolver struct{ *Resolver }
-type phasesResolver struct{ *Resolver }
-type queryResolver struct{ *Resolver }
-type tasksResolver struct{ *Resolver }
-type validatorResolver struct{ *Resolver }
+type (
+	identityResolver  struct{ *Resolver }
+	mutationResolver  struct{ *Resolver }
+	phaseResolver     struct{ *Resolver }
+	phasesResolver    struct{ *Resolver }
+	queryResolver     struct{ *Resolver }
+	tasksResolver     struct{ *Resolver }
+	validatorResolver struct{ *Resolver }
+)


### PR DESCRIPTION
Add a `override` flag to the `completeTask` mutation allowing to redefine the points attribution to a completed task.

In total transparency, this will be used in order to recompute the uptime of some validators which signed blocks have been tracked at some time for a different valoper address.