### PR TITLE
🐛 Initial zero point on new validator

### DIFF
--- a/app/nemeton/validator.go
+++ b/app/nemeton/validator.go
@@ -93,6 +93,7 @@ func NewValidator(
 		Discord:   discord,
 		Country:   country,
 		Status:    "inactive",
+		Points:    new(uint64),
 	}, nil
 }
 


### PR DESCRIPTION
Allocate zero point to the initial value on validator number of points at creation. Is to fix error when trying to register a new validator and nil points are allocated. 