### PR TITLE
ci(release): force node version to 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           token: ${{ secrets.OKP4_TOKEN }}
 
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
       - name: Setup Go environment
         uses: actions/setup-go@v4.0.1
         with:


### PR DESCRIPTION
Force node version in which semantic release is ran, this is a temporary hack to make it work: cycjimmy/semantic-release-action#159