### PR TITLE
ci: use node 16 for sementic release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Release project
         uses: cycjimmy/semantic-release-action@v3


### PR DESCRIPTION
To fix this deprecated message, try to change node version before release : https://github.com/okp4/nemeton-leaderboard/actions/runs/6011722947/job/16306082293#step:5:98