### PR TITLE
ci: udpate semantic-release-replace-plugin version to 1.2.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             @semantic-release/changelog
             @semantic-release/exec
             @semantic-release/git
-            semantic-release-replace-plugin@v1.2.0
+            semantic-release-replace-plugin@v1.2.7
           extends: |
             conventional-changelog-conventionalcommits
         env:


### PR DESCRIPTION
Update semantic-release-replace-plugin.