### PR TITLE
feat(cmd): allow to disable block sync

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,7 @@ const (
 	FlagTLSSkipVerify  = "tls-skip-verify"
 	FlagTwitterToken   = "twitter-token" // nolint:gosec
 	FlagTwitterAccount = "twitter-account"
+	FlagNoBlockSync    = "no-block-sync"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 	twitterToken   string
 	twitterAccount string
 	accessToken    string
+	noBlockSync    bool
 
 	startCmd = &cobra.Command{
 		Use:   "start",
@@ -54,6 +56,7 @@ var (
 				twitterAccount,
 				getTransportCredentials(),
 				accessTokenOpt,
+				noBlockSync,
 			)
 
 			kill := make(chan os.Signal, 1)
@@ -90,6 +93,7 @@ func init() {
 		"access-token",
 		"",
 		"The required access token for authenticated operations, an empty value = no auth")
+	startCmd.PersistentFlags().BoolVar(&noBlockSync, FlagNoBlockSync, false, "Disable block synchronization")
 }
 
 func getTransportCredentials() credentials.TransportCredentials {


### PR DESCRIPTION
Allow to disable the block synchronization through the command line argument `--no-block-sync`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to disable block synchronization during the application's bootstrap process.

- **Refactor**
  - Updated the bootstrap and start command functions to support the new no-block-sync feature.

- **Documentation**
  - Added descriptions for the new flag that controls block synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->